### PR TITLE
Use `@ExcludeFromJacocoGeneratedReport` to exclude method from jacoco

### DIFF
--- a/src/main/java/com/droidablebee/kafka/tool/KafkaTestToolApplication.java
+++ b/src/main/java/com/droidablebee/kafka/tool/KafkaTestToolApplication.java
@@ -1,5 +1,6 @@
 package com.droidablebee.kafka.tool;
 
+import com.droidablebee.kafka.tool.config.ExcludeFromJacocoGeneratedReport;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
@@ -11,6 +12,7 @@ public class KafkaTestToolApplication {
 
     static final String RANDOM_GROUP_ID = "--random-group-id";
 
+    @ExcludeFromJacocoGeneratedReport("This method is not used by the Spring integration tests annotated with @SpringBootTest")
     public static void main(String[] args) {
 
         System.setProperty("app.kafka.randomGroupIdSuffix", generateRandomGroupIdSuffix(args));
@@ -21,7 +23,7 @@ public class KafkaTestToolApplication {
 
         String randomGroupIdSuffix = "";
 
-        if(Arrays.asList(args).contains(RANDOM_GROUP_ID)) {
+        if (Arrays.asList(args).contains(RANDOM_GROUP_ID)) {
             randomGroupIdSuffix = "-" + UUID.randomUUID();
         }
 

--- a/src/main/java/com/droidablebee/kafka/tool/config/ExcludeFromJacocoGeneratedReport.java
+++ b/src/main/java/com/droidablebee/kafka/tool/config/ExcludeFromJacocoGeneratedReport.java
@@ -1,0 +1,26 @@
+package com.droidablebee.kafka.tool.config;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marker annotation that is used by Jacoco to exclude a method or a class from its coverage report.
+ * Annotation must have RetentionPolicy of CLASS or RUNTIME.
+ * Existing groovy or lombok @Generated annotation can be used.
+ * See <a href="https://github.com/jacoco/jacoco/pull/822/files">jacoco PR 822</a>.
+ * <pre>
+ * Classes and methods annotated with runtime visible and invisible annotation
+ * whose simple name contains "Generated" are filtered out during generation of report.
+ * </pre>
+ */
+@Retention(RetentionPolicy.CLASS)
+@Target({ElementType.METHOD, ElementType.TYPE})
+public @interface ExcludeFromJacocoGeneratedReport {
+
+    /**
+     * The reason for exclusion.
+     */
+    String[] value();
+}


### PR DESCRIPTION
Use `@ExcludeFromJacocoGeneratedReport` to exclude method from `jacoco` code coverage.

KafkaTestToolApplication.main() method is not used by the Spring integration tests with `@SpringBootTest`.